### PR TITLE
Added section describing possible values for `Instrumentation` annotation

### DIFF
--- a/content/en/docs/k8s-operator/automatic.md
+++ b/content/en/docs/k8s-operator/automatic.md
@@ -357,13 +357,16 @@ language-specific annotation:
 - Node.js: `instrumentation.opentelemetry.io/inject-nodejs: "true"`
 - Python: `instrumentation.opentelemetry.io/inject-python: "true"`
 
-
 The possible values for the annotation can be
-* `"true"` - to inject  `Instrumentation` resource with default name from the curent namespace.
-* `"my-instrumentation"` - to inject `Instrumentation` CR instance with name `"my-instrumentation"` in the current namespace.
-* `"my-other-namespace/my-instrumentation"` - to inject `Instrumentation` CR instance with name `"my-instrumentation"` from another namespace `"my-other-namespace"`.
-* `"false"` - do not inject
 
+- `"true"` - to inject `Instrumentation` resource with default name from the
+  curent namespace.
+- `"my-instrumentation"` - to inject `Instrumentation` CR instance with name
+  `"my-instrumentation"` in the current namespace.
+- `"my-other-namespace/my-instrumentation"` - to inject `Instrumentation` CR
+  instance with name `"my-instrumentation"` from another namespace
+  `"my-other-namespace"`.
+- `"false"` - do not inject
 
 Alternatively, the annotation can be added to a namespace, which will result in
 all services in that namespace to opt-in to autoinstrumentation. See the

--- a/content/en/docs/k8s-operator/automatic.md
+++ b/content/en/docs/k8s-operator/automatic.md
@@ -357,6 +357,14 @@ language-specific annotation:
 - Node.js: `instrumentation.opentelemetry.io/inject-nodejs: "true"`
 - Python: `instrumentation.opentelemetry.io/inject-python: "true"`
 
+
+The possible values for the annotation can be
+* `"true"` - to inject  `Instrumentation` resource with default name from the curent namespace.
+* `"my-instrumentation"` - to inject `Instrumentation` CR instance with name `"my-instrumentation"` in the current namespace.
+* `"my-other-namespace/my-instrumentation"` - to inject `Instrumentation` CR instance with name `"my-instrumentation"` from another namespace `"my-other-namespace"`.
+* `"false"` - do not inject
+
+
 Alternatively, the annotation can be added to a namespace, which will result in
 all services in that namespace to opt-in to autoinstrumentation. See the
 [Operators auto-instrumentation documentation](https://github.com/open-telemetry/opentelemetry-operator/blob/main/README.md#opentelemetry-auto-instrumentation-injection)


### PR DESCRIPTION
Annotation used to carry our auto instrumentation can take other values beyond `true` as mentioned here https://github.com/open-telemetry/opentelemetry-operator/blob/main/README.md#opentelemetry-auto-instrumentation-injection

It would be nice to document these values in the main docs. 